### PR TITLE
Update README to mention any caps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # GStreamer Subprocess Pipe Plugin
 
-A GStreamer plugin that creates a video sink element which pipes raw video frames to a subprocess command via stdin.
+A GStreamer plugin that creates a sink element which pipes raw frames to a subprocess command via stdin.
 
 ## Description
 
-The `videopipesink` element accepts raw video frames and forwards them to a subprocess command specified via the `cmd` property.
+The `videopipesink` element accepts raw frames and forwards them to a subprocess command specified via the `cmd` property.
 
 Key features:
-- Accepts any raw video format as input
+- Accepts any raw format as input
 - Runs a user-specified command as a subprocess
-- Pipes raw video frames to subprocess stdin
+- Pipes raw frames to subprocess stdin
 - Captures and logs subprocess stderr
 - Gracefully handles subprocess lifecycle (start/stop)
 
@@ -42,18 +42,18 @@ gst-launch-1.0 v4l2src ! videoconvert ! video/x-raw,format=RGB ! \
 
 ### Element Properties
 
-- `cmd` (string): Shell command that will receive raw video frames via stdin. Required.
+- `cmd` (string): Shell command that will receive raw frames via stdin. Required.
 
 ### Supported Formats
 
-The element accepts any raw video format supported by GStreamer's video conversion elements. Common formats include:
+The element accepts any raw format supported by GStreamer's conversion elements. Common formats include:
 - RGB, BGR
 - GRAY8, GRAY16_LE
 - YUV variants (I420, NV12, etc.)
 
 ### Behavior
 
-- Paces frame delivery according to video frame rate
+- Paces frame delivery according to frame rate
 - Sends SIGHUP and waits for subprocess to exit on pipeline stop
 - Logs subprocess stderr output and final return code
 - Propagates subprocess errors to the pipeline


### PR DESCRIPTION
Update the README.md file to reflect that the plugin accepts any caps, not just video.

* Update the description to mention that the plugin creates a sink element which pipes raw frames to a subprocess command via stdin.
* Update the `videopipesink` element description to mention that it accepts raw frames.
* Update the key features to mention that the plugin accepts any raw format as input and pipes raw frames to subprocess stdin.
* Update the `cmd` property description to mention that it will receive raw frames via stdin.
* Update the supported formats section to mention that the element accepts any raw format supported by GStreamer's conversion elements.
* Update the behavior section to mention that it paces frame delivery according to frame rate.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rafaelcaricio/gst-subprocess-pipe/pull/1?shareId=ba323748-1964-4673-82f6-b2c94d52c003).