### PR TITLE
Add GStreamer example using the plugin

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "build": "cargo check",
+    "test": "cargo test"
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,7 @@ import_library = false
 
 [package.metadata.capi.pkg_config]
 requires_private = "gstreamer-1.0, gstreamer-base-1.0, gstreamer-video-1.0, gobject-2.0, glib-2.0, gmodule-2.0"
+
+[[example]]
+name = "ffmpegsub"
+path = "examples/ffmpegsub.rs"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Enable debug output to see subprocess stderr and element state:
 GST_DEBUG=videopipesink:4 gst-launch-1.0 ...
 ```
 
+## Example GStreamer App
+
+An example GStreamer app using the `videopipesink` plugin is provided in the `examples` directory. The example sets up a GStreamer pipeline and uses the `videopipesink` element to pipe raw video frames to an `ffmpeg` command.
+
+### Running the Example
+
+To run the example, use the following command:
+
+```bash
+cargo run --example ffmpegsub
+```
+
 ## License
 
 This project is licensed under the Mozilla Public License 2.0.

--- a/examples/ffmpegsub.rs
+++ b/examples/ffmpegsub.rs
@@ -1,0 +1,50 @@
+use gst::prelude::*;
+use gst::ElementFactory;
+
+fn main() {
+    // Initialize GStreamer
+    gst::init().unwrap();
+
+    // Create the elements
+    let src = ElementFactory::make("videotestsrc", None).unwrap();
+    let convert = ElementFactory::make("videoconvert", None).unwrap();
+    let sink = ElementFactory::make("videopipesink", None).unwrap();
+
+    // Set the properties
+    src.set_property("is-live", &true).unwrap();
+    sink.set_property("cmd", &"ffmpeg -hide_banner -f rawvideo -pix_fmt yuv420p -s 320x240 -r 30 -i - -c:v libx264 -preset medium -movflags +faststart -f mp4 -y output.mp4").unwrap();
+
+    // Create the pipeline
+    let pipeline = gst::Pipeline::new(None);
+
+    // Add elements to the pipeline
+    pipeline.add_many(&[&src, &convert, &sink]).unwrap();
+
+    // Link the elements
+    src.link(&convert).unwrap();
+    convert.link(&sink).unwrap();
+
+    // Start playing
+    pipeline.set_state(gst::State::Playing).unwrap();
+
+    // Wait until error or EOS
+    let bus = pipeline.bus().unwrap();
+    for msg in bus.iter_timed(gst::ClockTime::NONE) {
+        match msg.view() {
+            gst::MessageView::Eos(..) => break,
+            gst::MessageView::Error(err) => {
+                eprintln!(
+                    "Error from {:?}: {} ({:?})",
+                    msg.src().map(|s| s.path_string()),
+                    err.error(),
+                    err.debug()
+                );
+                break;
+            }
+            _ => (),
+        }
+    }
+
+    // Clean up
+    pipeline.set_state(gst::State::Null).unwrap();
+}

--- a/examples/ffmpegsub.rs
+++ b/examples/ffmpegsub.rs
@@ -6,9 +6,9 @@ fn main() {
     gst::init().unwrap();
 
     // Create the elements
-    let src = ElementFactory::make("videotestsrc", None).unwrap();
-    let convert = ElementFactory::make("videoconvert", None).unwrap();
-    let sink = ElementFactory::make("videopipesink", None).unwrap();
+    let src = gst::ElementFactory::make("videotestsrc").build().unwrap();
+    let convert = gst::ElementFactory::make("videoconvert").build().unwrap();
+    let sink = gst::ElementFactory::make("videopipesink").build().unwrap();
 
     // Set the properties
     src.set_property("is-live", &true).unwrap();


### PR DESCRIPTION
Add an example GStreamer app using the `videopipesink` plugin.

* **Cargo.toml**
  - Add examples section pointing to the new example using ffmpeg.

* **examples/ffmpegsub.rs**
  - Create a new file `examples/ffmpegsub.rs`.
  - Add `main` function to set up a GStreamer pipeline.
  - Use `videopipesink` element in the pipeline.

* **README.md**
  - Add an example GStreamer app using the plugin.
  - Include instructions to run the example.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rafaelcaricio/gst-subprocess-pipe/pull/2?shareId=0bba1fe5-8181-49a0-957f-0134ade6b5b6).